### PR TITLE
GH-#989-Github-Issue-submission-from-Web-interface

### DIFF
--- a/Report_an_issue.html
+++ b/Report_an_issue.html
@@ -8,14 +8,14 @@
 
     <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
 
-    <title>Google Summer Of Code</title>
+    <title>PEcAn Team</title>
   </head>
 
   <body>
 
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
-                <header class="outer">
+        <header class="outer">
           <a id="forkme_banner" href="https://github.com/PecanProject">View on GitHub</a>
 
         <table><tr>
@@ -36,37 +36,16 @@
         </header>
     </div>
 
-      <!-- MAIN CONTENT -->
+    <!-- MAIN CONTENT -->
     <div id="main_content_wrap" class="outer">
       <section id="main_content" class="inner">
 
-<h4> On Slack</h4>
+        <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdNo42zV63L8bXo0gX5ag9-8Ut_pHwKIEmuEf7uXSOPA2JqAw/viewform?embedded=true" width="640" height="1504" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+  
+      </section>
+    </div>
 
-<p>We love to chat! You can join our chat room on Slack and ask us anything, anytime. All you need to  do is sign in on Slack using <a href="https://publicslack.com/slacks/pecanproject/invites/new">this link!</a></p>
-
-
-<h4><a href=https://github.com/PecanProject/pecan/issues>On GitHub</a></h4>
-
-<p>If you want to report a bug, ask a question, share an idea, discuss a topic or contribute, write to us on our GitHub repository. Pick a username, sign up for GitHub, open an issue... We will answer!</p>
-
-
-
-<h4><a href=https://twitter.com/PEcAnProject>On Twitter</a></h4>
-
-<p>Follow us, mention us, DM us on Twitter<p>
-
-
-<h4><p>By Email<p></h4>
-
-<p>Good old email: pecanproj [at] gmail.com<p>
-
- 
- 
- 
- 
- 
- 
-     <!-- FOOTER  -->
+    <!-- FOOTER  -->
     <div id="footer_wrap" class="outer">
       <footer class="inner">
         <p>Published with <a href="http://pages.github.com">GitHub Pages</a></p>
@@ -80,17 +59,9 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-28628282-1', 'pecanproject.github.io');
-      ga('require', 'displayfeatures');
       ga('send', 'pageview');
 
     </script>
-    <script>
-  ((window.gitter = {}).chat = {}).options = {
-    room: 'PecanProject/pecan'
-  };
-</script>
+
   </body>
 </html>
- 
- 
- 

--- a/documentation.html
+++ b/documentation.html
@@ -30,6 +30,7 @@
 <td><a href="pkgdocs.html">Package Documentation</a></td>
 <td><a href="pecan_workshop.html">Workshop</a></td>
 <td><a href="gsoc.html">GSoC</a></td>
+<td><a href="Report_an_issue.html">Report an Issue</a></td>
 <td><a href="contact.html">Contact Us</a></td>
 </tr></table>
         </header>

--- a/gsoc.html
+++ b/gsoc.html
@@ -30,6 +30,7 @@
 <td><a href="pkgdocs.html">Package Documentation</a></td>
 <td><a href="pecan_workshop.html">Workshop</a></td>
 <td><a href="gsoc.html">GSoC</a></td>
+<td><a href="Report_an_issue.html">Report an Issue</a></td>
 <td><a href="contact.html">Contact Us</a></td>
 </tr></table>
         </header>

--- a/gsoc_ideas.html
+++ b/gsoc_ideas.html
@@ -30,6 +30,7 @@
 <td><a href="pkgdocs.html">Package Documentation</a></td>
 <td><a href="pecan_workshop.html">Workshop</a></td>
 <td><a href="gsoc.html">GSoC</a></td>
+<td><a href="Report_an_issue.html">Report an Issue</a></td>
 <td><a href="contact.html">Contact Us</a></td>
 </tr></table>
         </header>

--- a/gsod.html
+++ b/gsod.html
@@ -31,6 +31,7 @@
 <td><a href="pecan_workshop.html">Workshop</a></td>
 <td><a href="gsoc.html">GSoC</a></td>
 <td><a href="gsod.html">GSoD</a></td>
+<td><a href="Report_an_issue.html">Report an Issue</a></td>
 <td><a href="contact.html">Contact Us</a></td>
 </tr></table>
         </header>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 <td><a href="pecan_workshop.html">Workshop</a></td>
 <td><a href="gsoc.html">GSoC</a></td>
 <td><a href="gsod.html">GSoD</a></td>
+<td><a href="Report_an_issue.html">Report an Issue</a></td>
 <td><a href="contact.html">Contact Us</a></td>
 </tr></table>
         </header>

--- a/news.html
+++ b/news.html
@@ -30,6 +30,7 @@
 <td><a href="pkgdocs.html">Package Documentation</a></td>
 <td><a href="pecan_workshop.html">Workshop</a></td>
 <td><a href="gsoc.html">GSoC</a></td>
+<td><a href="Report_an_issue.html">Report an Issue</a></td>
 <td><a href="contact.html">Contact Us</a></td>
 </tr></table>
         </header>

--- a/pecan_workshop.html
+++ b/pecan_workshop.html
@@ -30,6 +30,7 @@
 <td><a href="pkgdocs.html">Package Documentation</a></td>
 <td><a href="pecan_workshop.html">Workshop</a></td>
 <td><a href="gsoc.html">GSoC</a></td>
+<td><a href="Report_an_issue.html">Report an Issue</a></td>
 <td><a href="contact.html">Contact Us</a></td>
 </tr></table>
         </header>

--- a/people.html
+++ b/people.html
@@ -30,6 +30,7 @@
 <td><a href="pkgdocs.html">Package Documentation</a></td>
 <td><a href="pecan_workshop.html">Workshop</a></td>
 <td><a href="gsoc.html">GSoC</a></td>
+<td><a href="Report_an_issue.html">Report an Issue</a></td>
 <td><a href="contact.html">Contact Us</a></td>
 </tr></table>
         </header>

--- a/pkgdocs.html
+++ b/pkgdocs.html
@@ -30,6 +30,7 @@
 <td><a href="pkgdocs.html">Package Documentation</a></td>
 <td><a href="pecan_workshop.html">Workshop</a></td>
 <td><a href="gsoc.html">GSoC</a></td>
+<td><a href="Report_an_issue.html">Report an Issue</a></td>
 <td><a href="contact.html">Contact Us</a></td>
 </tr></table>
         </header>

--- a/tutorials.html
+++ b/tutorials.html
@@ -30,6 +30,7 @@
 <td><a href="pkgdocs.html">Package Documentation</a></td>
 <td><a href="pecan_workshop.html">Workshop</a></td>
 <td><a href="gsoc.html">GSoC</a></td>
+<td><a href="Report_an_issue.html">Report an Issue</a></td>
 <td><a href="contact.html">Contact Us</a></td>
 </tr></table>
         </header>


### PR DESCRIPTION
**Description**
This `PR fixes #989` (from repo PecanProject/pecan).

**Some notes:**
 -`Google Form API` to submit the ISSUES directly from the website without any Github account

**Review Time Estimate**
 When possible

**Types of changes**
 New feature (non-breaking change which adds functionality)