### PR TITLE
Fixed #57 (Search bar not visible)

### DIFF
--- a/src/pages/documentation/documentation.css
+++ b/src/pages/documentation/documentation.css
@@ -1,6 +1,6 @@
 .documentation .footer {
   display: none !important;
 }
-.documentation {
+/* .documentation {
   overflow-y: hidden !important;
-}
+} */


### PR DESCRIPTION
This PR fixes issue #57 .
**Issue**
Search bar becomes invisible after something is typed into it.

**Fix**
1. Minor css fix, the fix disables the overflow on the y-axis, in Documentation view.
2. Have attached the videos for tests on Chrome and Firefox. In the test, I type in the bar, the search focuses highlighted elements, then we press backspace key which deletes the input, upon scrolling up we observe the search bar is still present.

https://github.com/user-attachments/assets/6bd7aa8c-fe08-411b-b58e-fccbfe515684


https://github.com/user-attachments/assets/8e98a023-41f3-4721-8c56-6f7b0e6b3956


