### PR TITLE
GH-#70: Add PR template requiring mobile and desktop screenshots

### DIFF
--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,21 @@
+### Description of Changes
+- [ ] I have tested my changes on **both desktop and mobile views**.
+- [ ] Screenshots are attached below for desktop and mobile layouts.
+
+### Screenshots
+**Before Changes** (if applicable):
+- Desktop:  
+  ![Desktop Before](url-to-desktop-screenshot)
+- Mobile:  
+  ![Mobile Before](url-to-mobile-screenshot)
+
+**After Changes**:
+- Desktop:  
+  ![Desktop After](url-to-desktop-screenshot)
+- Mobile:  
+  ![Mobile After](url-to-mobile-screenshot)
+
+### How to Test Responsiveness
+- Use your browser’s **Developer Tools** (e.g., Chrome/Firefox) to toggle mobile views:
+  1. Right-click → **Inspect** → Click the **Device Toolbar** icon.
+  2. Select a mobile device (e.g., iPhone 12) or set a custom screen size.


### PR DESCRIPTION
fixes #70 

## Description

### Problem
Currently, contributors only include screenshots for large screens when making style changes or introducing new components. This often leads to visual bugs on small screens (e.g., mobile devices), breaking the UI while fixing other issues.

### Solution
This PR adds a **Pull Request template** that requires contributors to include screenshots for **both desktop and mobile views** when making UI changes. The template also provides instructions on how to test responsiveness using browser developer tools.

### Changes
- Added `.github/pull_request_template.md` with:
  - A section for **before/after screenshots** (desktop and mobile).
  
  