### PR TITLE
Add Navbar to Documentation Pages for All Releases After "Latest Code Documentation" #82

### DIFF
--- a/src/pages/documentation.js
+++ b/src/pages/documentation.js
@@ -2,172 +2,209 @@ import React from "react";
 import Layout from "@theme/Layout";
 import styles from "./about.module.css";
 import clsx from "clsx";
-function gsoc() {
-    return (
-        <Layout title="documentation">
-            <div className={styles.aboutContainer}>
-                <div className={clsx(styles.cardContainer)}>
-                    {" "}
-                    <div class={clsx("card-demo", styles.aboutCard)}>
-                        <div class="card">
-                            <div class="card__header" style={{ textAlign: "center" }}>
-
-                                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">Latest Release Documentation</h3>
-                            </div>
-                            <div class="card__body">
-                                <p>
-                                    <a href="documentation/master" class="text-size-20 text-m-size-16" ><u>Documentation consistent with latest release (MASTER BRANCH).</u></a>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div className={clsx(styles.cardContainer)}>
-                    {" "}
-                    <div class={clsx("card-demo", styles.aboutCard)}>
-                        <div class="card">
-                            <div class="card__header" style={{ textAlign: "center" }}>
-
-                                <h3 class="text-dark margin-bottom-30 margin-top-30 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">Latest Code Documentation</h3>
-
-                            </div>
-                            <div class="card__body">
-                                <p>
-                                    <a href="documentation/develop" class="text-size-20 text-m-size-16" ><u>Documentation consistent with latest stable code (DEVELOP BRANCH).</u></a>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div className={clsx(styles.cardContainer)}>
-                    {" "}
-                    <div class={clsx("card-demo", styles.aboutCard)}>
-                        <div class="card">
-                            <div class="card__header" style={{ textAlign: "center" }}>
-
-                                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">Release V1.7.1</h3>
-
-                            </div>
-                            <div class="card__body">
-                                <p>
-                                    <a href="https://pecanproject.github.io/pecan-documentation/v1.7.1" class="text-size-20 text-m-size-16" ><u>Documentation consistent with release 1.7.1</u></a>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div className={clsx(styles.cardContainer)}>
-                    {" "}
-                    <div class={clsx("card-demo", styles.aboutCard)}>
-                        <div class="card">
-                            <div class="card__header" style={{ textAlign: "center" }}>
-
-                                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">Release 1.7.0</h3>
-
-                            </div>
-                            <div class="card__body">
-                                <p>
-                                    <a href="https://pecanproject.github.io/pecan-documentation/1.7.0" class="text-size-20 text-m-size-16" ><u>Documentation consistent with release 1.7.0</u></a>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div className={clsx(styles.cardContainer)}>
-                    {" "}
-                    <div class={clsx("card-demo", styles.aboutCard)}>
-                        <div class="card">
-                            <div class="card__header" style={{ textAlign: "center" }}>
-
-                                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">Release V1.6.0</h3>
-
-                            </div>
-                            <div class="card__body">
-                                <p>
-                                    <a href="https://pecanproject.github.io/pecan-documentation/v1.6.0" class="text-size-20 text-m-size-16" ><u>Documentation consistent with release 1.6.0</u></a>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div className={clsx(styles.cardContainer)}>
-                    {" "}
-                    <div class={clsx("card-demo", styles.aboutCard)}>
-                        <div class="card">
-                            <div class="card__header" style={{ textAlign: "center" }}>
-
-                                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">Release V1.5.3</h3>
-
-                            </div>
-                            <div class="card__body">
-                                <p>
-                                    <a href="https://pecanproject.github.io/pecan-documentation/v1.5.3" class="text-size-20 text-m-size-16" ><u>Documentation consistent with release 1.5.3</u></a>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div className={clsx(styles.cardContainer)}>
-                    {" "}
-                    <div class={clsx("card-demo", styles.aboutCard)}>
-                        <div class="card">
-                            <div class="card__header" style={{ textAlign: "center" }}>
-
-
-                                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">Release V1.5.1</h3>
-
-                            </div>
-                            <div class="card__body">
-                                <p>
-                                    <a href="https://pecanproject.github.io/pecan-documentation/v1.5.1" class="text-size-20 text-m-size-16" ><u>Documentation consistent with release 1.5.1</u></a>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div className={clsx(styles.cardContainer)}>
-                    {" "}
-                    <div class={clsx("card-demo", styles.aboutCard)}>
-                        <div class="card">
-                            <div class="card__header" style={{ textAlign: "center" }}>
-
-
-                                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">Release V1.5.0</h3>
-
-                            </div>
-                            <div class="card__body">
-                                <p>
-                                    <a href="https://pecanproject.github.io/pecan-documentation/1.5.0" class="text-size-20 text-m-size-16" ><u>Documentation consistent with release 1.5.0</u></a>
-
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={clsx(styles.cardContainer)}>
-                    {" "}
-                    <div class={clsx("card-demo", styles.aboutCard)}>
-                        <div class="card">
-                            <div class="card__header" style={{ textAlign: "center" }}>
-
-                                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">Release V1.4.10.1</h3>
-
-                            </div>
-                            <div class="card__body">
-                                <p>
-                                    <a href="https://pecanproject.github.io/pecan-documentation/1.4.10.1/" class="text-size-20 text-m-size-16" ><u>Documentation consistent with release 1.4.10.1</u></a>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-
-
+function Documentation() {
+  return (
+    <Layout title="documentation">
+      <div className={styles.aboutContainer}>
+        <div className={clsx(styles.cardContainer)}>
+          <div class={clsx("card-demo", styles.aboutCard)}>
+            <div class="card">
+              <div class="card__header" style={{ textAlign: "center" }}>
+                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">
+                  Latest Release Documentation
+                </h3>
+              </div>
+              <div class="card__body">
+                <p>
+                  <a
+                    href="documentation/master"
+                    class="text-size-20 text-m-size-16"
+                  >
+                    <u>
+                      Documentation consistent with latest release (MASTER
+                      BRANCH).
+                    </u>
+                  </a>
+                </p>
+              </div>
             </div>
-        </Layout>
-    );
+          </div>
+        </div>
+        <div className={clsx(styles.cardContainer)}>
+          <div class={clsx("card-demo", styles.aboutCard)}>
+            <div class="card">
+              <div class="card__header" style={{ textAlign: "center" }}>
+                <h3 class="text-dark margin-bottom-30 margin-top-30 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">
+                  Latest Code Documentation
+                </h3>
+              </div>
+              <div class="card__body">
+                <p>
+                  <a
+                    href="documentation/develop"
+                    class="text-size-20 text-m-size-16"
+                  >
+                    <u>
+                      Documentation consistent with latest stable code (DEVELOP
+                      BRANCH).
+                    </u>
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className={clsx(styles.cardContainer)}>
+          <div class={clsx("card-demo", styles.aboutCard)}>
+            <div class="card">
+              <div class="card__header" style={{ textAlign: "center" }}>
+                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">
+                  Release V1.7.1
+                </h3>
+              </div>
+              <div class="card__body">
+                <p>
+                  <a
+                    href="documentation/version171"
+                    class="text-size-20 text-m-size-16"
+                  >
+                    <u>Documentation consistent with release 1.7.1</u>
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className={clsx(styles.cardContainer)}>
+          <div class={clsx("card-demo", styles.aboutCard)}>
+            <div class="card">
+              <div class="card__header" style={{ textAlign: "center" }}>
+                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">
+                  Release 1.7.0
+                </h3>
+              </div>
+              <div class="card__body">
+                <p>
+                  <a
+                    href="documentation/version170"
+                    class="text-size-20 text-m-size-16"
+                  >
+                    <u>Documentation consistent with release 1.7.0</u>
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className={clsx(styles.cardContainer)}>
+          <div class={clsx("card-demo", styles.aboutCard)}>
+            <div class="card">
+              <div class="card__header" style={{ textAlign: "center" }}>
+                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">
+                  Release V1.6.0
+                </h3>
+              </div>
+              <div class="card__body">
+                <p>
+                  <a
+                    href="documentation/version160"
+                    class="text-size-20 text-m-size-16"
+                  >
+                    <u>Documentation consistent with release 1.6.0</u>
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className={clsx(styles.cardContainer)}>
+          <div class={clsx("card-demo", styles.aboutCard)}>
+            <div class="card">
+              <div class="card__header" style={{ textAlign: "center" }}>
+                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">
+                  Release V1.5.3
+                </h3>
+              </div>
+              <div class="card__body">
+                <p>
+                  <a
+                    href="documentation/version153"
+                    class="text-size-20 text-m-size-16"
+                  >
+                    <u>Documentation consistent with release 1.5.3</u>
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className={clsx(styles.cardContainer)}>
+          <div class={clsx("card-demo", styles.aboutCard)}>
+            <div class="card">
+              <div class="card__header" style={{ textAlign: "center" }}>
+                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">
+                  Release V1.5.1
+                </h3>
+              </div>
+              <div class="card__body">
+                <p>
+                  <a
+                    href="documentation/version151"
+                    class="text-size-20 text-m-size-16"
+                  >
+                    <u>Documentation consistent with release 1.5.1</u>
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className={clsx(styles.cardContainer)}>
+          <div class={clsx("card-demo", styles.aboutCard)}>
+            <div class="card">
+              <div class="card__header" style={{ textAlign: "center" }}>
+                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">
+                  Release V1.5.0
+                </h3>
+              </div>
+              <div class="card__body">
+                <p>
+                  <a
+                    href="documentation/version150"
+                    class="text-size-20 text-m-size-16"
+                  >
+                    <u>Documentation consistent with release 1.5.0</u>
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className={clsx(styles.cardContainer)}>
+          <div class={clsx("card-demo", styles.aboutCard)}>
+            <div class="card">
+              <div class="card__header" style={{ textAlign: "center" }}>
+                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">
+                  Release V1.4.10.1
+                </h3>
+              </div>
+              <div class="card__body">
+                <p>
+                  <a
+                    href="documentation/version14101"
+                    class="text-size-20 text-m-size-16"
+                  >
+                    <u>Documentation consistent with release 1.4.10.1</u>
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
 }
 
-export default gsoc;
+export default Documentation;

--- a/src/pages/documentation/version14101.js
+++ b/src/pages/documentation/version14101.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import "./documentation.css";
+import Foot from "@docusaurus/Head";
+function Versioin14101() {
+  return (
+    <>
+      <Layout title="Versioin14101">
+        <Foot>
+          <body className="documentation"></body>
+        </Foot>
+        <iframe
+          src="https://pecanproject.github.io/pecan-documentation/1.4.10.1/"
+          style={{ border: "none" }}
+          width="100%"
+          height="100%"
+          id="iFrame9"
+        >
+          <p>
+            <a href="/en-US/docs/Glossary">
+              Fallback link for browsers that don't support iframes
+            </a>
+          </p>
+        </iframe>
+      </Layout>
+    </>
+  );
+}
+
+export default Versioin14101;

--- a/src/pages/documentation/version150.js
+++ b/src/pages/documentation/version150.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import "./documentation.css";
+import Foot from "@docusaurus/Head";
+function Versioin150() {
+  return (
+    <>
+      <Layout title="Versioin150">
+        <Foot>
+          <body className="documentation"></body>
+        </Foot>
+        <iframe
+          src="https://pecanproject.github.io/pecan-documentation/1.5.0"
+          style={{ border: "none" }}
+          width="100%"
+          height="100%"
+          id="iFrame8"
+        >
+          <p>
+            <a href="/en-US/docs/Glossary">
+              Fallback link for browsers that don't support iframes
+            </a>
+          </p>
+        </iframe>
+      </Layout>
+    </>
+  );
+}
+
+export default Versioin150;

--- a/src/pages/documentation/version151.js
+++ b/src/pages/documentation/version151.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import "./documentation.css";
+import Foot from "@docusaurus/Head";
+function Versioin151() {
+  return (
+    <>
+      <Layout title="Versioin151">
+        <Foot>
+          <body className="documentation"></body>
+        </Foot>
+        <iframe
+          src="https://pecanproject.github.io/pecan-documentation/v1.5.1"
+          style={{ border: "none" }}
+          width="100%"
+          height="100%"
+          id="iFrame7"
+        >
+          <p>
+            <a href="/en-US/docs/Glossary">
+              Fallback link for browsers that don't support iframes
+            </a>
+          </p>
+        </iframe>
+      </Layout>
+    </>
+  );
+}
+
+export default Versioin151;

--- a/src/pages/documentation/version153.js
+++ b/src/pages/documentation/version153.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import "./documentation.css";
+import Foot from "@docusaurus/Head";
+function Versioin153() {
+  return (
+    <>
+      <Layout title="Versioin153">
+        <Foot>
+          <body className="documentation"></body>
+        </Foot>
+        <iframe
+          src="https://pecanproject.github.io/pecan-documentation/v1.5.3"
+          style={{ border: "none" }}
+          width="100%"
+          height="100%"
+          id="iFrame6"
+        >
+          <p>
+            <a href="/en-US/docs/Glossary">
+              Fallback link for browsers that don't support iframes
+            </a>
+          </p>
+        </iframe>
+      </Layout>
+    </>
+  );
+}
+
+export default Versioin153;

--- a/src/pages/documentation/version160.js
+++ b/src/pages/documentation/version160.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import "./documentation.css";
+import Foot from "@docusaurus/Head";
+function Versioin160() {
+  return (
+    <>
+      <Layout title="Versioin160">
+        <Foot>
+          <body className="documentation"></body>
+        </Foot>
+        <iframe
+          src="https://pecanproject.github.io/pecan-documentation/v1.6.0"
+          style={{ border: "none" }}
+          width="100%"
+          height="100%"
+          id="iFrame5"
+        >
+          <p>
+            <a href="/en-US/docs/Glossary">
+              Fallback link for browsers that don't support iframes
+            </a>
+          </p>
+        </iframe>
+      </Layout>
+    </>
+  );
+}
+
+export default Versioin160;

--- a/src/pages/documentation/version170.js
+++ b/src/pages/documentation/version170.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import "./documentation.css";
+import Foot from "@docusaurus/Head";
+function Versioin170() {
+  return (
+    <>
+      <Layout title="Versioin170">
+        <Foot>
+          <body className="documentation"></body>
+        </Foot>
+        <iframe
+          src="https://pecanproject.github.io/pecan-documentation/1.7.0"
+          style={{ border: "none" }}
+          width="100%"
+          height="100%"
+          id="iFrame4"
+        >
+          <p>
+            <a href="/en-US/docs/Glossary">
+              Fallback link for browsers that don't support iframes
+            </a>
+          </p>
+        </iframe>
+      </Layout>
+    </>
+  );
+}
+
+export default Versioin170;

--- a/src/pages/documentation/version171.js
+++ b/src/pages/documentation/version171.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import "./documentation.css";
+import Foot from "@docusaurus/Head";
+function Versioin171() {
+  return (
+    <>
+      <Layout title="Versioin171">
+        <Foot>
+          <body className="documentation"></body>
+        </Foot>
+        <iframe
+          src="https://pecanproject.github.io/pecan-documentation/v1.7.1"
+          style={{ border: "none" }}
+          width="100%"
+          height="100%"
+          id="iFrame3"
+        >
+          <p>
+            <a href="/en-US/docs/Glossary">
+              Fallback link for browsers that don't support iframes
+            </a>
+          </p>
+        </iframe>
+      </Layout>
+    </>
+  );
+}
+
+export default Versioin171;


### PR DESCRIPTION
Fixed: [#82](https://github.com/PecanProject/PecanProject.github.io/issues/82)

This PR adds a navbar to the documentation pages for all releases listed after "Latest Code Documentation." Previousl , these versioned documentation pages did not have a navbar, making navigation inconsistent. This update ensures that users can easily switch between different documentation versions without relying on external links or manual navigation.


Befor:
![Screenshot 2025-02-16 113800](https://github.com/user-attachments/assets/829dfef3-c0aa-405a-bd98-6eaf1c5422cc)

After:
![Screenshot 2025-02-16 113728](https://github.com/user-attachments/assets/46393a33-bc74-4ee4-a23a-221a912f9746)

Let me know if you need any modifications! 🚀

Looking forward to your( @dlebauer ) response. Thanks in advance!
