### PR TITLE
Added missing 'V' in Release 1.7.0 title for consistency

### DIFF
--- a/src/pages/documentation.js
+++ b/src/pages/documentation.js
@@ -62,7 +62,7 @@ function gsoc() {
                         <div class="card">
                             <div class="card__header" style={{ textAlign: "center" }}>
 
-                                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">Release 1.7.0</h3>
+                                <h3 class="text-dark margin-bottom-30 margin-top-60 margin-m-top-30 text-size-20 text-m-size-16 text-line-height-1">Release V1.7.0</h3>
 
                             </div>
                             <div class="card__body">


### PR DESCRIPTION
Fixed:  [#84](https://github.com/PecanProject/PecanProject.github.io/issues/84)

This PR fixes the issue where "Release 1.7.0" was incorrectly displayed without the "V" prefix on the documentation page. To maintain consistency across all release versions, "V" has been added, ensuring uniform formatting in version labels.

Befor:

![Screenshot 2025-02-16 132554](https://github.com/user-attachments/assets/32a39978-02fa-4c08-a164-44668bd33753)

After:

![Screenshot 2025-02-16 133032](https://github.com/user-attachments/assets/40cd4716-d05f-41d6-8370-f5bc961e90b6)

Let me know if any further modifications are needed
