### PR TITLE
Readme/update contributing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ Changes to `package-lock.json` and `yarn.lock` files should only be committed wh
 - Updating an existing dependency: Running an update for a package will adjust these files to reflect the new versions.
 - Removing a dependency: Uninstalling a package will update these files to remove the reference to the dependency.
 
+### Content File Formats
+
+**Use `.md` or `.mdx` file formats** MDX is a markdown format that allows embedded JSX components for more flexibility. Refer to the Docusaurus Docs page [MDX and React](https://docusaurus.io/docs/markdown-features/react) for information on MDX syntax and capabilities.
+
+**Always link using explicit heading IDs** when adding or editing headings in a `.md` or `.mdx` file. This prevents broken links if heading text changes later. For example:
+
+```markdown
+    ### My Important Section{#my-important-section}
+```
+  Then, you can link to this section using:
+
+ ```markdown
+    [Link to my section](#my-important-section)
+ ```
+
 ### Add or Edit Feature Cards
 
 Feature Cards on the website homepage highlight the key features of the PEcAn Project.
@@ -177,6 +192,8 @@ tags: [gsoc, gsoc21]
 ---
 ```
 
+
+<!-- These screenshots are large and don't appear to be in the right place, if necessary
 ## Screenshots
 
 This section contains screenshots of website's homepage in light and dark theme.
@@ -184,21 +201,7 @@ This section contains screenshots of website's homepage in light and dark theme.
 ![LightTheme](screenshots/light.png)
 
 ![DarkTheme](screenshots/dark.png)
-
-## Editing a Documentation File
-The PEcAn documentation is a crucial part of the project.  We aim to make it comprehensive, accurate, and easy to navigate. When contributing to documentation, please keep the following in mind:
-
-*   **Always use explicit heading IDs** when adding or editing headings in documentation file(`.mdx`). This prevents broken links if heading text changes later. For example:
-
-```markdown
-    ### My Important Section{#my-important-section}
-```
-  Then, you can link to this section using:
-
- ```markdown
-    [Link to my section](#my-important-section)
- ```
-*   **Use appropriate file formats**, primarily Markdown (`.md`) and MDX (`.mdx`). MDX allows embedding JSX components within documentation for more flexibility. Refer to [Docusaurus Docs](https://docusaurus.io/docs) for MDX syntax.
+-->
 
 ## Next Steps
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,21 @@ All involved are expected to follow the [PEcAn code of conduct](https://pecanpro
 
 First time contributors are welcome. Contributions can be very simple, make sure to check out beginner friendly issues, if present.
 
+## Editing a Documentation File
+The PEcAn documentation is a crucial part of the project.  We aim to make it comprehensive, accurate, and easy to navigate. When contributing to documentation, please keep the following in mind:
+
+*   **Always use explicit heading IDs** when adding or editing headings in documentation file(`.mdx`). This prevents broken links if heading text changes later. For example:
+
+```markdown
+    ### My Important Section{#my-important-section}
+```
+  Then, you can link to this section using:
+
+ ```markdown
+    [Link to my section](#my-important-section)
+ ```
+*   **Use appropriate file formats**, primarily Markdown (`.md`) and MDX (`.mdx`). MDX allows embedding JSX components within documentation for more flexibility. Refer to [Docusaurus Docs](https://docusaurus.io/docs) for MDX syntax.
+
 ## Next Steps
 
 This section contains future plans for the website. New contributors can use this section as a reference for planning their contributions.

--- a/src/pages/gsoc.js
+++ b/src/pages/gsoc.js
@@ -28,7 +28,7 @@ function gsoc() {
 
                             <p>&nbsp;</p>
 
-                            <h2><a href="gsoc_apply">How to apply?</a></h2>
+                            <h2><a href="#how-to-apply" onClick={(e) => e.preventDefault()}>How to apply?</a></h2>
 
                             There are two steps to the application process:
 
@@ -49,15 +49,13 @@ function gsoc() {
 
                             <ul>
                                 <li>Choose a project from our <a href="gsoc_ideas.html">project ideas list</a> or come up with your own.</li>
-                                <li>Join the #gsoc-2023 channel in our slack workspace and introduce yourself</li>
+                                <li>Join the <a href="https://pecanproject.slack.com/archives/C0853U6GF71" target="_blank" rel="noopener noreferrer">#gsoc-2025</a> channel in our slack workspace and introduce yourself</li>
                                 <li>Send message to your project-specific mentors indicating that you are interested in their idea and how you plan to implement the idea</li>
                             </ul>
 
                             <p>&nbsp;</p>
 
-                            When talking to the mentors, use the following questions to introuduce yourself:
-
-                            <p>&nbsp;</p>
+                            <h3>When talking to the mentors, use the following questions to introuduce yourself:</h3>
 
                             <ul>
                                 <li>What interests you most about our project?</li>


### PR DESCRIPTION
This PR updates the Contributing section in the README to include guidelines for adding or editing documentation pages. It specifies the use of explicit heading IDs to prevent broken links when headings change and provides details on supported file formats (.md, .mdx). A reference to the official Docusaurus documentation is also included for further guidance.