### PR TITLE
update tutorials page with v1.10.0 demos and restructure layout

### DIFF
--- a/src/pages/tutorials.js
+++ b/src/pages/tutorials.js
@@ -11,6 +11,27 @@ function Tutorials() {
                     <h1>
                         <a name="background" class="anchor" href="#background"><span class="octicon octicon-link"></span></a>Hands On Demos:</h1>
 
+                    <div>PEcAn Tutorial v1.10.0
+                        &nbsp;  &nbsp;  &nbsp;  &nbsp;
+                        <a href="https://pecanproject.github.io/pecan-documentation/develop/run-demo-1.html" target="_blank" rel="nofollow">Tutorial 1</a>
+                        &nbsp;  &nbsp;  &nbsp;  &nbsp;
+                        <a href="https://pecanproject.github.io/pecan-documentation/develop/run-demo-2.html" target="_blank" rel="nofollow">Tutorial 2</a>
+                    </div>
+                    
+                    <div><br /></div>
+
+                    <h4>Flux Course 2012: PEcAn Tutorial</h4>
+
+                    <section id="main_content" class="inner">
+
+                        <iframe width="560" height="315" src="//www.youtube.com/embed/S_y6SnO7Hbw" frameborder="0" allowfullscreen></iframe>
+
+                    </section>
+
+                    <div><br /></div>
+
+                    <h1>Tutorials from previous Releases</h1>
+
                     <div>PEcAn Tutorial v1.5.2
                         &nbsp;  &nbsp;  &nbsp;  &nbsp;
                         <a href="https://pecanproject.github.io/pecan-documentation/tutorials/Demo01.html" target="_blank" rel="nofollow">Tutorial 1</a>
@@ -123,13 +144,6 @@ function Tutorials() {
                     {/* <!--<div>In 2012 PEcAn was used in an educational setting at two different summer short courses, PalEON's "Assimilating Long-Term Data into Ecosystem Models" week-long summer course" and the Niwot Ridge flux course ""Summer Course in Flux Measurements and Advanced Modeling". PEcAn was also used at the Ecosystem Demography Model training workshop at Harvard University in January 2012.</div>
 <div><br /></div> --> */}
 
-                    <h4>Flux Course 2012: PEcAn Tutorial</h4>
-
-                    <section id="main_content" class="inner">
-
-                        <iframe width="560" height="315" src="//www.youtube.com/embed/S_y6SnO7Hbw" frameborder="0" allowfullscreen></iframe>
-
-                    </section>
                 </div>
             </div>
         </Layout>


### PR DESCRIPTION
Since we now have proper Quarto notebook documentation added to the PEcAn tutorial section, this PR adds links to those tutorials as suggested in issue https://github.com/PecanProject/pecan/issues/3610.

This may require releasing v1.10.0 before we can merge it, though I'm not entirely sure.

part of https://github.com/PecanProject/pecan/issues/3610