### PR TITLE
Add GSoC redirect HTML page

### DIFF
--- a/static/gsoc.html
+++ b/static/gsoc.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting to GSoC</title>
+  <meta http-equiv="refresh" content="0; URL=/gsoc">
+  <link rel="canonical" href="/gsoc">
+</head>
+<body>
+  <p>Redirecting to <a href="/gsoc">/gsoc</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
Problem:
- broken link to pecanproject.github.io/gsoc.html
- website currently has a /gsoc endpoint, but not /gsoc.html.
- there are still links in the wild to gsoc.html (it existed on the old website)

Solution:
- add simple html redirect and there are still links to it.