### PR TITLE
feat: add publications page link to navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,31 +23,31 @@ module.exports = {
           position: "left",
           items: [
             {
-              to: "/documentation", label: "Documentation",
+              to: "/documentation/", label: "Documentation",
             },
             {
-              to: "/package-documentation/develop", label: "Package Documentation",
+              to: "/package-documentation/develop/", label: "Package Documentation",
             },
             {
-              to: "/tutorials", label: "Tutorials",
+              to: "/tutorials/", label: "Tutorials",
             },
             {
               to: "http://pecan.ncsa.illinois.edu/pecan/01-introduction.php", label: "Demo"
             },
           ],
         },
-        { to: "/blog", label: "Blog", position: "left" },
+        { to: "/blog/", label: "Blog", position: "left" },
         {
           label: "About",
           position: "left",
           items: [
-            { to: "/about", label: "About" },
-            { to: "/people", label: "People" },
-            { to: "/alumni", label: "Alumni" },
-            { to: "/news", label: "News" },
+            { to: "/about/", label: "About" },
+            { to: "/people/", label: "People" },
+            { to: "/alumni/", label: "Alumni" },
+            { to: "/news/", label: "News" },
           ],
         },
-        { to: "/publications", label: "Publications", position: "left" },
+        { to: "/publications/", label: "Publications", position: "left" },
         {
           href: "https://github.com/PecanProject",
           position: "right",
@@ -58,8 +58,8 @@ module.exports = {
           label: "GSoC",
           position: "left",
           items: [
-            { to: "/gsoc", label: "Contributor Guidance" },
-            { to: "/gsoc_ideas", label: "Ideas List" }
+            { to: "/gsoc/", label: "Contributor Guidance" },
+            { to: "/gsoc_ideas/", label: "Ideas List" },
           ],
         },
       ],
@@ -71,7 +71,7 @@ module.exports = {
           items: [
             {
               label: "Tutorial",
-              to: "/documentation/latest",
+              to: "/documentation/latest/",
               className: "footer-docs-link",
             },
           ],


### PR DESCRIPTION
### Summary

This PR fixes broken internal navigation links caused by missing trailing slashes on GitHub Pages.

Some pages (e.g. `/documentation`, `/gsoc`) were being linked without a trailing slash, while the actual pages are generated at `/path/`. GitHub Pages does not automatically redirect these URLs, resulting in 404 errors.

---

### What was happening

- Pages exist at `/documentation/`, `/gsoc/`, etc.
- Navbar links pointed to `/documentation`, `/gsoc`
- Visiting the non-slash URLs resulted in a 404 page
- Browsers often autocomplete to the non-slash version, making this issue frequent

---

### What this PR changes

- Standardizes internal navbar links to always use trailing slashes:
  - `/documentation/`
  - `/package-documentation/develop/`
  - `/tutorials/`
  - `/gsoc/`
- Aligns link usage with Docusaurus and GitHub Pages routing behavior

---

### Why this matters

- Prevents 404 errors for valid pages
- Improves navigation reliability
- Avoids confusion caused by browser URL autocompletion
- Addresses the root cause discussed in issue #136 and related link issues

---

### How to test

1. Visit https://pecanproject.github.io/
2. Use the navbar to navigate to:
   - Documentation → Documentation
   - Documentation → Package Documentation
   - GSoC → Contributor Guidance
3. Confirm that all links load correctly without 404 errors

---

### Notes

This PR focuses on fixing existing broken links and does not add automated link checking or redirects, which could be handled in a follow-up issue.
