### PR TITLE
create pkg documentation landing page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,7 +26,7 @@ module.exports = {
               to: "/documentation/", label: "Documentation",
             },
             {
-              to: "/package-documentation/develop/", label: "Package Documentation",
+              to: "/package-documentation/", label: "Package Documentation",
             },
             {
               to: "/tutorials/", label: "Tutorials",

--- a/src/pages/package-documentation/index.md
+++ b/src/pages/package-documentation/index.md
@@ -1,0 +1,13 @@
+# Package Documentation
+
+Please select the package documentation version that matches your version of PEcAn.
+
+## Working Draft
+* [Package documentation consistent with unreleased code (`develop` branch)](pathname:///package-documentation/develop/)
+
+## Latest Release
+* [Package documentation consistent with latest release (`main` branch)](pathname:///package-documentation/latest/)
+
+## Releases by tag
+* [v1.10.0](pathname:///package-documentation/v1.10.0/)
+* [v1.9.0](pathname:///package-documentation/v1.9.0/)


### PR DESCRIPTION
Implement a multi-version landing page for pkg documentation at /package-documentation/.
Fixes #146 

<img width="1807" height="976" alt="image" src="https://github.com/user-attachments/assets/f8d85cc5-060a-4384-b0b3-1e4a95917f7a" />
